### PR TITLE
Add Archive Notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# libixcom
+# [DEPRECATED] libixcom
+
+#### This repository is no longer active. The project has been merged into [gnss-converters](https://github.com/swift-nav/gnss-converters.git). ####
 
 [![CI](https://github.com/swift-nav/libixcom/actions/workflows/ci.yaml/badge.svg)](https://github.com/swift-nav/libixcom/actions/workflows/ci.yaml)
 


### PR DESCRIPTION
Adds a notice to the readme that the project has been deprecated and moved to gnss-converters.

This is to prepare for archiving the repository.